### PR TITLE
fixes frozen error and keep setting frozen_string_literal: true

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-
+# frozen_string_literal: true
 
 # read more about what rake does
 # https://github.com/ruby/rake

--- a/app.rb
+++ b/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # require gems and libs
 require 'sinatra'
 require 'sinatra/base'

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,4 +1,4 @@
-
+# frozen_string_literal: true
 
 class MyApp < Sinatra::Base
   # initialize new sprockets environment

--- a/config/timezone.rb
+++ b/config/timezone.rb
@@ -1,4 +1,4 @@
-
+# frozen_string_literal: true
 
 require 'active_support/core_ext/time'
 require 'active_support/core_ext/date'

--- a/controllers/welcome_controller.rb
+++ b/controllers/welcome_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Welcome controller
 # @controller_name is used for declaring class on html body
 # this is how you can make use of your javascript dependent on the conroller

--- a/db/migrate/20170218192415_create_skeleton.rb
+++ b/db/migrate/20170218192415_create_skeleton.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSkeleton < ActiveRecord::Migration[5.0]
   def change
     create_table :skeletons do |t|

--- a/db/migrate/20170219142151_create_user.rb
+++ b/db/migrate/20170219142151_create_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUser < ActiveRecord::Migration[5.0]
   def change
     create_table :users do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # seed your database
 # rake db:seed
 Skeleton.create(name: 'Marley')

--- a/lib/warden.rb
+++ b/lib/warden.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MyApp < Sinatra::Base
   use Warden::Manager do |config|
     # Tell Warden how to save our User info into a session.
@@ -28,7 +30,7 @@ class MyApp < Sinatra::Base
     env['REQUEST_METHOD'] = 'POST'
     # And we need to do the following to work with  Rack::MethodOverride
     env.each do |key, _value|
-      env[key]['_method'] = 'post' if key == 'rack.request.form_hash'
+      env[key]['_method'] = 'post'.dup if key == 'rack.request.form_hash'
     end
   end
   Warden::Strategies.add(:password) do

--- a/lib/warden.rb
+++ b/lib/warden.rb
@@ -30,7 +30,7 @@ class MyApp < Sinatra::Base
     env['REQUEST_METHOD'] = 'POST'
     # And we need to do the following to work with  Rack::MethodOverride
     env.each do |key, _value|
-      env[key]['_method'] = 'post'.dup if key == 'rack.request.form_hash'
+      env[key]['_method'] = +'post' if key == 'rack.request.form_hash'
     end
   end
   Warden::Strategies.add(:password) do

--- a/models/skeleton.rb
+++ b/models/skeleton.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # sample Model model with a validation
 # hook is set in the corresponding route for saving a model
 class Skeleton < ActiveRecord::Base

--- a/models/user.rb
+++ b/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The user class requires "BCrypt" to validate the encrypted password in the database.
 class User < ActiveRecord::Base
   include BCrypt

--- a/routes/routes.rb
+++ b/routes/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # routes
 # * you can have as many files as you like
 # * make sure to not to have duplicate routes!

--- a/routes/skeleton_routes.rb
+++ b/routes/skeleton_routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MyApp < Sinatra::Base
   get '/skeletons' do
     # view that displays data, see: views/skeletons.haml

--- a/routes/user_routes.rb
+++ b/routes/user_routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MyApp < Sinatra::Base
   get '/users/:id' do
     env['warden'].authenticate!


### PR DESCRIPTION
Hey! I actually found a way to fix this issue and keep the frozen_string_literal setting.

Here's the magic:

```
-      env[key]['_method'] = 'post' if key == 'rack.request.form_hash'
+      env[key]['_method'] = 'post'.dup if key == 'rack.request.form_hash'
```

Sinatra <= 2.0.3 doesn't like frozen string literals in the `env` hash.